### PR TITLE
Multiple GOPATH

### DIFF
--- a/internal/binding/parser/parser.go
+++ b/internal/binding/parser/parser.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"encoding/xml"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/therecipe/qt/internal/utils"
@@ -40,32 +39,40 @@ var (
 	SubnamespaceMap = make(map[string]bool)
 )
 
-func GetModule(s string) *Module {
+func GetModule(s string) (*Module, error) {
+
+	goPath, err := utils.GoPath()
+	if err != nil {
+		return nil, err
+	}
 
 	if s == "sailfish" {
 		var m = sailfishModule()
 		m.Prepare()
-		return m
+		return m, nil
 	}
 
 	var m = new(Module)
 	switch {
 	case utils.UseHomeBrew():
 		{
-			xml.Unmarshal([]byte(utils.Load(filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "therecipe", "qt", "internal", "binding", "files", "docs", "5.7.0", fmt.Sprintf("qt%v.index", s)))), &m)
+			err = xml.Unmarshal([]byte(utils.Load(filepath.Join(goPath, "src", "github.com", "therecipe", "qt", "internal", "binding", "files", "docs", "5.7.0", fmt.Sprintf("qt%v.index", s)))), &m)
 		}
 
 	case utils.UsePkgConfig():
 		{
-			xml.Unmarshal([]byte(utils.Load(filepath.Join(utils.QT_DOC_DIR(), fmt.Sprintf("qt%v", s), fmt.Sprintf("qt%v.index", s)))), &m)
+			err = xml.Unmarshal([]byte(utils.Load(filepath.Join(utils.QT_DOC_DIR(), fmt.Sprintf("qt%v", s), fmt.Sprintf("qt%v.index", s)))), &m)
 		}
 
 	default:
 		{
-			xml.Unmarshal([]byte(utils.Load(filepath.Join(utils.QT_DIR(), "Docs", "Qt-5.7", fmt.Sprintf("qt%v", s), fmt.Sprintf("qt%v.index", s)))), &m)
+			err = xml.Unmarshal([]byte(utils.Load(filepath.Join(utils.QT_DIR(), "Docs", "Qt-5.7", fmt.Sprintf("qt%v", s), fmt.Sprintf("qt%v.index", s)))), &m)
 		}
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	m.Prepare()
-	return m
+	return m, nil
 }

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -161,7 +161,7 @@ func args() {
 }
 
 func moc() {
-	utils.RunCmd(exec.Command(filepath.Join(os.Getenv("GOPATH"), "bin", "qtmoc"), appPath, "cleanup"), "qtdeploy.moc")
+	utils.RunCmd(exec.Command(filepath.Join(utils.MustGoPath(), "bin", "qtmoc"), appPath, "cleanup"), "qtdeploy.moc")
 }
 
 func qrc() {

--- a/internal/minimal/minimal.go
+++ b/internal/minimal/minimal.go
@@ -16,7 +16,7 @@ import (
 
 var BuildTarget string
 
-func Minimal(path string) {
+func Minimal(path string) error {
 
 	var (
 		imported []string
@@ -72,7 +72,9 @@ func Minimal(path string) {
 	}
 
 	for _, module := range templater.GetLibs() {
-		parser.GetModule(strings.ToLower(module))
+		if _, err := parser.GetModule(strings.ToLower(module)); err != nil {
+			return err
+		}
 	}
 
 	var file = strings.Join(cached, "")
@@ -130,6 +132,7 @@ func Minimal(path string) {
 	for _, module := range templater.GetLibs() {
 		templater.GenModule(module)
 	}
+	return nil
 }
 
 func exportFunction(class *parser.Class, function *parser.Function) {

--- a/internal/setup/check.go
+++ b/internal/setup/check.go
@@ -17,20 +17,29 @@ func main() {
 		buildTarget = os.Args[1]
 	}
 
-	if _, err := ioutil.ReadDir(os.Getenv("GOPATH")); err != nil {
+	gopaths := os.Getenv("GOPATH")
+	if len(gopaths) == 0 {
 		fmt.Print("\nerror:\nGOPATH not set\nsolution: define GOPATH\n\n")
 		os.Exit(1)
 	}
 
-	if strings.Contains(os.Getenv("GOPATH"), runtime.GOROOT()) {
-		fmt.Print("\nerror:\nGOPATH is or contains GOROOT\n\n")
-		os.Exit(1)
+	for _, path :=  range strings.Split(gopaths, ":") {
+		if _, err := ioutil.ReadDir(path); err != nil {
+			fmt.Printf("\nerror:\nInvalid GOPATH %q\nsolution: specify valid GOPATH\n\n", path)
+			os.Exit(1)
+		}
+
+		if strings.Contains(path, runtime.GOROOT()) {
+			fmt.Printf("\nerror:\nGOPATH %q is or contains GOROOT\n\n", path)
+			os.Exit(1)
+		}
+
+		if strings.Contains(runtime.GOROOT(), path) {
+			fmt.Printf("\nerror:\nGOROOT is or contains GOPATH %q\n\n", path)
+			os.Exit(1)
+		}
 	}
 
-	if strings.Contains(runtime.GOROOT(), os.Getenv("GOPATH")) {
-		fmt.Print("\nerror:\nGOROOT is or contains GOPATH\n\n")
-		os.Exit(1)
-	}
 
 	if _, err := ioutil.ReadDir(utils.QT_DIR()); err != nil && !utils.UsePkgConfig() {
 		fmt.Printf("\nerror: Qt not found\nsolution: install Qt in \"%v\" or define QT_DIR\n\n", utils.QT_DIR())

--- a/internal/setup/check.go
+++ b/internal/setup/check.go
@@ -50,7 +50,7 @@ func main() {
 	case "darwin":
 		{
 			if _, err := exec.LookPath("clang++"); err != nil {
-				fmt.Printf("\nerror: clang++ not found\nsolution: install Xcode\n\n")
+				fmt.Print("\nerror: clang++ not found\nsolution: install Xcode\n\n")
 				os.Exit(1)
 			}
 		}
@@ -58,7 +58,7 @@ func main() {
 	case "linux":
 		{
 			if _, err := exec.LookPath("g++"); err != nil {
-				fmt.Printf("\nerror: g++ not found\nsolution: sudo apt-get -y install build-essential\n\n")
+				fmt.Print("\nerror: g++ not found\nsolution: sudo apt-get -y install build-essential\n\n")
 				os.Exit(1)
 			}
 		}
@@ -66,7 +66,7 @@ func main() {
 	case "windows":
 		{
 			if _, err := exec.LookPath("g++"); err != nil {
-				fmt.Printf("\nerror: g++ not found\nsolution: add the directory that contains \"g++\" to your PATH\n\n")
+				fmt.Print("\nerror: g++ not found\nsolution: add the directory that contains \"g++\" to your PATH\n\n")
 				os.Exit(1)
 			}
 		}

--- a/internal/setup/check.go
+++ b/internal/setup/check.go
@@ -16,11 +16,7 @@ func main() {
 		buildTarget = os.Args[1]
 	}
 
-	if _, err := utils.GoPath();  err != nil {
-		fmt.Printf("\nerror:\n%s\n\n", err.Error())
-		os.Exit(1)
-	}
-
+	_ = utils.MustGoPath()
 
 	if _, err := ioutil.ReadDir(utils.QT_DIR()); err != nil && !utils.UsePkgConfig() {
 		fmt.Printf("\nerror: Qt not found\nsolution: install Qt in \"%v\" or define QT_DIR\n\n", utils.QT_DIR())

--- a/internal/setup/check.go
+++ b/internal/setup/check.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 
 	"github.com/therecipe/qt/internal/utils"
 )
@@ -17,27 +16,9 @@ func main() {
 		buildTarget = os.Args[1]
 	}
 
-	gopaths := os.Getenv("GOPATH")
-	if len(gopaths) == 0 {
-		fmt.Print("\nerror:\nGOPATH not set\nsolution: define GOPATH\n\n")
+	if _, err := utils.GoPath();  err != nil {
+		fmt.Printf("\nerror:\n%s\n\n", err.Error())
 		os.Exit(1)
-	}
-
-	for _, path :=  range strings.Split(gopaths, ":") {
-		if _, err := ioutil.ReadDir(path); err != nil {
-			fmt.Printf("\nerror:\nInvalid GOPATH %q\nsolution: specify valid GOPATH\n\n", path)
-			os.Exit(1)
-		}
-
-		if strings.Contains(path, runtime.GOROOT()) {
-			fmt.Printf("\nerror:\nGOPATH %q is or contains GOROOT\n\n", path)
-			os.Exit(1)
-		}
-
-		if strings.Contains(runtime.GOROOT(), path) {
-			fmt.Printf("\nerror:\nGOROOT is or contains GOPATH %q\n\n", path)
-			os.Exit(1)
-		}
 	}
 
 

--- a/internal/setup/generate.go
+++ b/internal/setup/generate.go
@@ -16,7 +16,10 @@ func main() {
 		fmt.Println("------------------------generate------------------------")
 
 		for _, module := range templater.GetLibs() {
-			parser.GetModule(strings.ToLower(module))
+			if _, err := parser.GetModule(strings.ToLower(module)); err != nil {
+				fmt.Println(err.Error())
+				os.Exit(1)
+			}
 		}
 
 		for _, module := range templater.GetLibs() {

--- a/internal/setup/test.go
+++ b/internal/setup/test.go
@@ -26,13 +26,13 @@ func main() {
 
 	fmt.Println("------------------------test----------------------------")
 
-	utils.MakeFolder(filepath.Join(os.Getenv("GOPATH"), "bin"))
+	utils.MakeFolder(filepath.Join(utils.MustGoPath(), "bin"))
 
-	utils.RemoveAll(filepath.Join(os.Getenv("GOPATH"), "bin", fmt.Sprintf("qtdeploy%v", ending)))
-	utils.RemoveAll(filepath.Join(os.Getenv("GOPATH"), "bin", fmt.Sprintf("qtmoc%v", ending)))
+	utils.RemoveAll(filepath.Join(utils.MustGoPath(), "bin", fmt.Sprintf("qtdeploy%v", ending)))
+	utils.RemoveAll(filepath.Join(utils.MustGoPath(), "bin", fmt.Sprintf("qtmoc%v", ending)))
 
-	utils.RunCmd(exec.Command("go", "build", "-o", filepath.Join(os.Getenv("GOPATH"), "bin", fmt.Sprintf("qtdeploy%v", ending)), utils.GoQtPkgPath("internal", "deploy", "deploy.go")), "qtdeploy")
-	utils.RunCmd(exec.Command("go", "build", "-o", filepath.Join(os.Getenv("GOPATH"), "bin", fmt.Sprintf("qtmoc%v", ending)), utils.GoQtPkgPath("internal", "moc", "moc.go")), "qtmoc")
+	utils.RunCmd(exec.Command("go", "build", "-o", filepath.Join(utils.MustGoPath(), "bin", fmt.Sprintf("qtdeploy%v", ending)), utils.GoQtPkgPath("internal", "deploy", "deploy.go")), "qtdeploy")
+	utils.RunCmd(exec.Command("go", "build", "-o", filepath.Join(utils.MustGoPath(), "bin", fmt.Sprintf("qtmoc%v", ending)), utils.GoQtPkgPath("internal", "moc", "moc.go")), "qtmoc")
 
 	switch runtime.GOOS {
 	case "darwin", "linux":
@@ -40,8 +40,8 @@ func main() {
 			utils.RemoveAll(filepath.Join("/usr", "local", "bin", "qtdeploy"))
 			utils.RemoveAll(filepath.Join("/usr", "local", "bin", "qtmoc"))
 
-			utils.RunCmdOptional(exec.Command("ln", "-s", filepath.Join(os.Getenv("GOPATH"), "bin", "qtdeploy"), filepath.Join("/usr", "local", "bin", "qtdeploy")), "symlink.qtdeploy")
-			utils.RunCmdOptional(exec.Command("ln", "-s", filepath.Join(os.Getenv("GOPATH"), "bin", "qtmoc"), filepath.Join("/usr", "local", "bin", "qtmoc")), "symlink.qtmoc")
+			utils.RunCmdOptional(exec.Command("ln", "-s", filepath.Join(utils.MustGoPath(), "bin", "qtdeploy"), filepath.Join("/usr", "local", "bin", "qtdeploy")), "symlink.qtdeploy")
+			utils.RunCmdOptional(exec.Command("ln", "-s", filepath.Join(utils.MustGoPath(), "bin", "qtmoc"), filepath.Join("/usr", "local", "bin", "qtmoc")), "symlink.qtmoc")
 		}
 
 	case "windows":
@@ -49,11 +49,11 @@ func main() {
 			utils.RemoveAll(filepath.Join(runtime.GOROOT(), "bin", fmt.Sprintf("qtdeploy%v", ending)))
 			utils.RemoveAll(filepath.Join(runtime.GOROOT(), "bin", fmt.Sprintf("qtmoc%v", ending)))
 
-			var cmdDeploy = exec.Command("cmd", "/C", "mklink", "/H", fmt.Sprintf("qtdeploy%v", ending), filepath.Join(os.Getenv("GOPATH"), "bin", fmt.Sprintf("qtdeploy%v", ending)))
+			var cmdDeploy = exec.Command("cmd", "/C", "mklink", "/H", fmt.Sprintf("qtdeploy%v", ending), filepath.Join(utils.MustGoPath(), "bin", fmt.Sprintf("qtdeploy%v", ending)))
 			cmdDeploy.Dir = filepath.Join(runtime.GOROOT(), "bin")
 			utils.RunCmdOptional(cmdDeploy, "symlink.qtdeploy")
 
-			var cmdMoc = exec.Command("cmd", "/C", "mklink", "/H", fmt.Sprintf("qtmoc%v", ending), filepath.Join(os.Getenv("GOPATH"), "bin", fmt.Sprintf("qtmoc%v", ending)))
+			var cmdMoc = exec.Command("cmd", "/C", "mklink", "/H", fmt.Sprintf("qtmoc%v", ending), filepath.Join(utils.MustGoPath(), "bin", fmt.Sprintf("qtmoc%v", ending)))
 			cmdMoc.Dir = filepath.Join(runtime.GOROOT(), "bin")
 			utils.RunCmdOptional(cmdMoc, "symlink.qtmoc")
 		}
@@ -74,7 +74,7 @@ func main() {
 			fmt.Print(example)
 
 			//TODO:
-			utils.RunCmd(exec.Command(filepath.Join(os.Getenv("GOPATH"), "bin", "qtdeploy"), "test", buildTarget, filepath.Join(utils.GoQtPkgPath("internal", "examples"), example)), fmt.Sprintf("test.%v", example))
+			utils.RunCmd(exec.Command(filepath.Join(utils.MustGoPath(), "bin", "qtdeploy"), "test", buildTarget, filepath.Join(utils.GoQtPkgPath("internal", "examples"), example)), fmt.Sprintf("test.%v", example))
 
 			fmt.Println(strings.Repeat(" ", 45-len(example)), time.Since(before)/time.Second*time.Second)
 		}

--- a/internal/utils/gopath.go
+++ b/internal/utils/gopath.go
@@ -12,6 +12,23 @@ import (
 
 const packageName = "github.com/therecipe/qt"
 
+var goPath *string
+
+// MustGoPath is same as GoPath but exit if any error
+// it also cache the result
+func MustGoPath() string {
+	if goPath != nil {
+		return *goPath
+	}
+	out, err := GoPath()
+	if err != nil {
+		fmt.Println("Error:", err.Error())
+		os.Exit(1)
+	}
+	goPath = &out
+	return out
+}
+
 // GoPath return the GOPATH where hold this package.
 func GoPath() (goPath string , err error) {
 	goPaths := os.Getenv("GOPATH")

--- a/internal/utils/gopath.go
+++ b/internal/utils/gopath.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"os"
+	"strings"
+	"io/ioutil"
+	"fmt"
+	"errors"
+	"runtime"
+	"path/filepath"
+)
+
+const packageName = "github.com/therecipe/qt"
+
+// GoPath return the GOPATH where hold this package.
+func GoPath() (goPath string , err error) {
+	goPaths := os.Getenv("GOPATH")
+	if len(goPaths) == 0 {
+		err = errors.New("GOPATH environment variable is unset")
+		return
+	}
+
+	tries := make([]string, 0)
+	for _, path := range strings.Split(goPaths, ":") {
+		if _, err = ioutil.ReadDir(path); err != nil {
+			err = fmt.Errorf("GOPATH %q point to a non-existing directory", path)
+			return
+		}
+
+		if strings.Contains(path, runtime.GOROOT()) {
+			err = fmt.Errorf("GOPATH %q is or contains GOROOT", path)
+			return
+		}
+
+		if strings.Contains(runtime.GOROOT(), path) {
+			err = fmt.Errorf("nGOROOT %q is or contains GOPATH", path)
+			return
+		}
+
+		packageDir := filepath.Join(path, "src", packageName)
+		if _, err = ioutil.ReadDir(packageDir); err == nil {
+			if len(goPath) > 0 {
+				err = fmt.Errorf("Multiple copies of %s are in GOPATH: in %s and %s", packageName, goPath, path)
+				return
+			}
+			goPath = path
+		} else {
+			tries = append(tries, packageDir)
+		}
+	}
+
+	if len(goPath) == 0 {
+		err = fmt.Errorf("Couldn't find %s in all %d GOPATH, tried: %s", packageName, len(tries), strings.Join(tries, " "))
+	}
+	return
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -55,7 +55,7 @@ func GetAbsPath(appPath string) string {
 }
 
 func GoQtPkgPath(s ...string) string {
-	return filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "therecipe", "qt", filepath.Join(s...))
+	return filepath.Join(MustGoPath(), "src", "github.com", "therecipe", "qt", filepath.Join(s...))
 }
 
 func Exists(name string) bool {


### PR DESCRIPTION
https://golang.org/doc/code.html#GOPATH

Can be more than one value such as `GOPATH=/path/to/a:/path/to/b`

On my setup, I couldn't run `internal/setup/*.go`, I started to fix it in this PR.
and started to return error value.

There is plenty of other usage of `os.GetEnv('GOPATH')` which wasn't triggered in my installation. I was about to change them, but wasn't sure if I was going to break something else.

When #72 will be fixed `MustGoPath` usage must be replaced by `GoPath`.