### PR TITLE
Fix unwanted error when using multiple gopaths

### DIFF
--- a/internal/utils/gopath.go
+++ b/internal/utils/gopath.go
@@ -48,17 +48,17 @@ func gopath() (goPath string, err error) {
 	for _, path := range strings.Split(goPaths, string(os.PathListSeparator)) {
 		if _, err = ioutil.ReadDir(path); err != nil {
 			err = fmt.Errorf("GOPATH %q point to a non-existing directory", path)
-			return
+			continue
 		}
 
 		if strings.HasPrefix(fmt.Sprintf("%v%v", path, string(os.PathSeparator)), fmt.Sprintf("%v%v", runtime.GOROOT(), string(os.PathSeparator))) {
 			err = fmt.Errorf("GOPATH %q is or contains GOROOT", path)
-			return
+			continue
 		}
 
 		if strings.HasPrefix(fmt.Sprintf("%v%v", runtime.GOROOT(), string(os.PathSeparator)), fmt.Sprintf("%v%v", path, string(os.PathSeparator))) {
 			err = fmt.Errorf("GOROOT %q is or contains GOPATH", path)
-			return
+			continue
 		}
 
 		var packageDir = filepath.Join(path, "src", packageName)
@@ -68,6 +68,8 @@ func gopath() (goPath string, err error) {
 				return
 			}
 			goPath = path
+			err = nil
+			break
 		} else {
 			tries = append(tries, packageDir)
 		}


### PR DESCRIPTION
Hello :)

I am playing around with your project and I have noticed that it does not handle well case when you have multiple gopaths defined in `GOPATH`.

The error it prints is `ERRO[0000] failed to get GOPATH that holds github.com/therecipe/qt  error="open /usr/local/gotools/src/github.com/therecipe/qt: no such file or directory"`, but `qtsetup` is able to continue normally.

I have located the cause of error in file `gopath.go`, as it tries to search all directories defined in `GOPATH`, but if an error occurs it handle it as fatal error (returning intermediately). I have changed the behavior to use `continue` on error and set `err = nil` if a valid `GOPATH` is found. Also it breaks from loop if valid `GOPATH` is found, as I think there is no need to continue looping once everything is found :)

best, az 