### PR TITLE
Allow qtdeploy to embed resources in all situations

### DIFF
--- a/cmd/qtrcc/qtrcc.go
+++ b/cmd/qtrcc/qtrcc.go
@@ -22,6 +22,16 @@ func main() {
 			var tmp_output_dir, _ = utils.Abs(*output_dir)
 			output_dir = &tmp_output_dir
 		}
+	} else {
+		env_output_dir := os.Getenv("QTRCC_OUTPUT_DIR")
+		if env_output_dir != "" {
+			if !filepath.IsAbs(env_output_dir) {
+				var tmp_output_dir, _ = utils.Abs(env_output_dir)
+				output_dir = &tmp_output_dir
+			} else {
+				output_dir = &env_output_dir
+			}
+		}
 	}
 
 	switch flag.NArg() {

--- a/cmd/qtrcc/qtrcc.go
+++ b/cmd/qtrcc/qtrcc.go
@@ -13,6 +13,9 @@ import (
 
 func main() {
 	var appPath, _ = os.Getwd()
+	if env_cwd := os.Getenv("QTRCC_CWD"); env_cwd != "" {
+		appPath = env_cwd
+	}
 
 	var output_dir = flag.String("o", "", "define alternative output dir")
 	cmd.ParseFlags()

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -84,7 +84,15 @@ func Deploy(s *State) {
 			} else {
 
 				//rcc
-				rcc.Rcc(appPath, nil)
+				var qtrcc_cwd string = appPath
+				if env_cwd := os.Getenv("QTRCC_CWD"); env_cwd != "" {
+					qtrcc_cwd = env_cwd
+				}
+				var qtrcc_output *string
+				if env_output_dir := os.Getenv("QTRCC_OUTPUT_DIR"); env_output_dir != "" {
+					qtrcc_output = &env_output_dir
+				}
+				rcc.Rcc(qtrcc_cwd, qtrcc_output)
 
 				//moc
 				moc.MocTree(appPath)


### PR DESCRIPTION
**Problem:**

Right now qtdeploy does not account for custom `.qrc` files when bundling resources. Also despite actual `$CWD` it assumes (without option to customize) main package directory as `$CWD` for qtrcc.

**Solution:**

For both `qtrcc` and `qtdeploy` implement unified way to provide output directory and cwd of `qtrcc`. In this changeset this is done via reading environment variables `QTRCC_CWD` for CWD location and `QTRCC_OUTPUT_DIR` as output location.

This has been tested on Mac OS Sierra and works as expected.

In case of `qtrcc` CLI call it assumes following priority - CLI arguments, environment variables

In case of `qtdeploy` there is no CLI arguments passed to `qtrcc`, thus the priority is on environment variables.