### PR TITLE
Fix errors with QT v5.2.0.

### DIFF
--- a/internal/binding/parser/function.go
+++ b/internal/binding/parser/function.go
@@ -230,7 +230,10 @@ func (f *Function) IsSupported() bool {
 }
 
 func (f *Function) IsDerivedFromVirtual() bool {
-	var class, _ = f.Class()
+	var class, ok = f.Class()
+	if !ok {
+		return false
+	}
 
 	if f.Virtual != "non" {
 		return true

--- a/internal/cmd/minimal/minimal.go
+++ b/internal/cmd/minimal/minimal.go
@@ -153,7 +153,12 @@ func Minimal(appPath, buildTarget string) {
 	}
 
 	if buildTarget == "sailfish" || buildTarget == "sailfish-emulator" {
-		parser.State.ClassMap["QQuickWidget"].Export = false
+		if _, ok := parser.State.ClassMap["QQuickWidget"]; ok {
+			parser.State.ClassMap["QQuickWidget"].Export = false
+		}
+		if _, ok := parser.State.ClassMap["TestCase"]; ok {
+			delete(parser.State.ClassMap, "TestCase")
+		}
 	}
 
 	if buildTarget == "ios" || buildTarget == "ios-simulator" {


### PR DESCRIPTION
Sailfish still uses QT v5.2 and qtsetup/qtminimal were failing. This
commit fixes nil pointer errors by adding checks for unsupported
classes.