### PR TITLE
Add support for AsteroidOS

### DIFF
--- a/internal/cmd/minimal/minimal.go
+++ b/internal/cmd/minimal/minimal.go
@@ -183,6 +183,33 @@ func Minimal(appPath, buildTarget string) {
 		}
 	}
 
+	if buildTarget == "asteroid" {
+		if _, ok := parser.State.ClassMap["TestCase"]; ok {
+			delete(parser.State.ClassMap, "TestCase")
+		}
+		if _, ok := parser.State.ClassMap["QQuickWidget"]; ok {
+			parser.State.ClassMap["QQuickWidget"].Export = false
+		}
+
+		for k, c := range parser.State.ClassMap {
+			switch c.Since {
+			case "5.7", "5.8":
+				delete(parser.State.ClassMap, c.Name)
+			}
+
+			for _, f := range c.Functions {
+				switch f.Since {
+				case "5.7", "5.8":
+					f.Export = false
+				}
+			}
+
+			if strings.HasPrefix(k, "QAccessible") {
+				delete(parser.State.ClassMap, k)
+			}
+		}
+	}
+
 	if buildTarget == "ios" || buildTarget == "ios-simulator" {
 		parser.State.ClassMap["QProcess"].Export = false
 		parser.State.ClassMap["QProcessEnvironment"].Export = false

--- a/internal/cmd/moc/moc.go
+++ b/internal/cmd/moc/moc.go
@@ -201,7 +201,7 @@ func CleanPath(path string) (err error) {
 			"moc_cgo_desktop_darwin_amd64.go", "moc_cgo_desktop_windows_386.go", "moc_cgo_desktop_windows_amd64.go", "moc_cgo_desktop_linux_amd64.go",
 			"moc_cgo_android_linux_arm.go",
 			"moc_cgo_ios_simulator_darwin_amd64.go", "moc_cgo_ios_simulator_darwin_386.go", "moc_cgo_ios_darwin_arm64.go", "moc_cgo_ios_darwin_arm.go",
-			"moc_cgo_sailfish_emulator_linux_386.go", "moc_cgo_sailfish_linux_arm.go",
+			"moc_cgo_sailfish_emulator_linux_386.go", "moc_cgo_sailfish_linux_arm.go", "moc_cgo_asteroid_linux_arm.go",
 			"moc_cgo_rpi1_linux_arm.go", "moc_cgo_rpi2_linux_arm.go", "moc_cgo_rpi3_linux_arm.go",
 		}
 

--- a/internal/cmd/rcc/rcc.go
+++ b/internal/cmd/rcc/rcc.go
@@ -106,7 +106,7 @@ func Rcc(appPath, buildTarget string, output_dir *string) {
 //TODO: make docker compatible
 func qmlHeader(appName string) string {
 
-	return strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(`package main
+	return strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(strings.Replace(`package main
 
 /*
 #cgo +build windows,386 windows,amd64 LDFLAGS: -L${QT_WINDOWS_DIR} -lQt5Core
@@ -134,6 +134,8 @@ func qmlHeader(appName string) string {
 
 #cgo +build sailfish_emulator,linux,386 LDFLAGS: -Wl,-rpath,/usr/share/harbour-${APPNAME}/lib -Wl,-rpath-link,/srv/mer/targets/SailfishOS-i486/usr/lib -Wl,-rpath-link,/srv/mer/targets/SailfishOS-i486/lib -L/srv/mer/targets/SailfishOS-i486/usr/lib -L/srv/mer/targets/SailfishOS-i486/lib -lQt5Core
 #cgo +build sailfish,linux,arm LDFLAGS: -Wl,-rpath,/usr/share/harbour-${APPNAME}/lib -Wl,-rpath-link,/srv/mer/targets/SailfishOS-armv7hl/usr/lib -Wl,-rpath-link,/srv/mer/targets/SailfishOS-armv7hl/lib -L/srv/mer/targets/SailfishOS-armv7hl/usr/lib -L/srv/mer/targets/SailfishOS-armv7hl/lib -lQt5Core
+
+#cgo +build asteroid,linux,arm LDFLAGS: -Wl,-rpath-link,${OECORE_TARGET_SYSROOT}/usr/lib -Wl,-rpath-link,${OECORE_TARGET_SYSROOT}/lib -L${OECORE_TARGET_SYSROOT}/usr/lib -L${OECORE_TARGET_SYSROOT}/lib -lQt5Core
 
 
 #cgo +build rpi1,linux,arm LDFLAGS: -Wl,-rpath-link,${RPI1_SYSROOT_DIR}/opt/vc/lib -Wl,-rpath-link,${RPI1_SYSROOT_DIR}/usr/lib/arm-linux-gnueabihf -Wl,-rpath-link,${RPI1_SYSROOT_DIR}/lib/arm-linux-gnueabihf -Wl,-rpath-link,${QT_DIR}/${QT_VERSION_MAJOR}/rpi1/lib -mfloat-abi=hard --sysroot=${RPI1_SYSROOT_DIR} -Wl,-O1 -Wl,--enable-new-dtags -Wl,-z,origin -L${RPI1_SYSROOT_DIR}/opt/vc/lib -L${QT_DIR}/${QT_VERSION_MAJOR}/rpi1/lib -lQt5Core
@@ -168,6 +170,7 @@ import "C"`,
 		"${IPHONEOS_SDK_DIR}", utils.IPHONEOS_SDK_DIR(), -1),
 		"${IPHONESIMULATOR_SDK_DIR}", utils.IPHONESIMULATOR_SDK_DIR(), -1),
 		"${APPNAME}", appName, -1),
+		"${OECORE_TARGET_SYSROOT}", os.Getenv("OECORE_TARGET_SYSROOT"), -1),
 		"${QT_VERSION_MAJOR}", utils.QT_VERSION_MAJOR(), -1),
 		"\\", "/", -1)
 }


### PR DESCRIPTION
AsteroidOS is an open-source operating system for smartwatches [1] built on Qt 5.6 and OpenEmbedded. This commit adds initial support for compiling Go Qt programs against the AsteroidOS SDK toolchain. The SDK includes a script that gets sourced before every build and we use the
OECORE_TARGET_SYSROOT env variable when generating the cgo source files. Information on building the SDK can be found here [2]. There is currently no emulator for AsteroidOS so this commit does not add any code to qtdeploy. Most of the changes are based off the Sailfish code.

Tested using Qt 5.7.0 official prebuilt package and the latest AsteroidOS SDK.

[1] https://asteroidos.org/
[2] https://asteroidos.org/wiki/creating-an-asteroid-app/