### PR TITLE
Add pkg-config based Qt version detection

### DIFF
--- a/internal/utils/env.go
+++ b/internal/utils/env.go
@@ -13,6 +13,10 @@ func QT_VERSION() string {
 		return version
 	}
 
+	if QT_PKG_CONFIG() {
+		return strings.TrimSpace(RunCmd(exec.Command("pkg-config", "--modversion", "Qt5Core"), "cgo.LinuxPkgConfig_modVersion"))
+	}
+
 	return "5.8.0"
 }
 


### PR DESCRIPTION
This patch adds detection of the version of Qt. Not sure if it will work on all platforms but my first thought is that it should.