### PR TITLE
install binding binaries

### DIFF
--- a/internal/docker/linux/Dockerfile
+++ b/internal/docker/linux/Dockerfile
@@ -37,3 +37,4 @@ ENV QT_DIR /opt/Qt5.8.0
 RUN $GOPATH/bin/qtsetup prep linux
 RUN $GOPATH/bin/qtsetup check linux
 RUN $GOPATH/bin/qtsetup generate linux
+RUN $GOPATH/bin/qtsetup install linux


### PR DESCRIPTION
Docker images aren't super efficient.

every time go toolchains run inside it and it deal with code that import `github.com/therecipe/qt` it rebuild all `therecipe/qt/*` bindings.

that requires a lot of memory and CPU time.

this is only for `therecipe/qt:linux`, you should do the same for all other images too