### PR TITLE
Examples: SqlModels fix

### DIFF
--- a/internal/examples/sql/querymodel/customsqlmodel.go
+++ b/internal/examples/sql/querymodel/customsqlmodel.go
@@ -14,7 +14,7 @@ type CustomSqlModel struct {
 }
 
 func newCustomSqlModel(p *core.QObject) *CustomSqlModel {
-	var model = NewCustomSqlModel(p)
+	var model = &CustomSqlModel{*sql.NewQSqlQueryModel(p)}
 
 	model.ConnectData(model.data)
 

--- a/internal/examples/sql/querymodel/editablesqlmodel.go
+++ b/internal/examples/sql/querymodel/editablesqlmodel.go
@@ -11,7 +11,7 @@ type EditableSqlModel struct {
 }
 
 func newEditableSqlModel(p *core.QObject) *EditableSqlModel {
-	var model = NewEditableSqlModel(p)
+	var model = &EditableSqlModel{*sql.NewQSqlQueryModel(p)}
 
 	model.ConnectFlags(model.flags)
 	model.ConnectSetData(model.setData)


### PR DESCRIPTION
The example `sql/querymodel` did not work for me, because of the missing functions `NewCustomSqlModel` and `NewEditableSqlModel` however a fix is available.