### PR TITLE
Replace import path 'Sirupsen/logrus' with 'sirupsen/logrus'

### DIFF
--- a/internal/binding/parser/parser.go
+++ b/internal/binding/parser/parser.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/therecipe/qt/internal/utils"
 )
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/therecipe/qt/internal/utils"
 )

--- a/internal/docker/linux/Dockerfile
+++ b/internal/docker/linux/Dockerfile
@@ -24,8 +24,8 @@ ENV GOPATH $HOME/work
 
 
 RUN go get -v github.com/therecipe/qt/cmd/...
-RUN rm -r /home/user/work/src/github.com/Sirupsen/ && rm -r /home/user/work/src/golang.org/
-RUN rm -r /home/user/work/pkg/linux_amd64/github.com/Sirupsen/ && rm -r /home/user/work/pkg/linux_amd64/golang.org/
+RUN rm -r /home/user/work/src/github.com/sirupsen/ && rm -r /home/user/work/src/golang.org/
+RUN rm -r /home/user/work/pkg/linux_amd64/github.com/sirupsen/ && rm -r /home/user/work/pkg/linux_amd64/golang.org/
 
 
 ENV QT qt-unified-linux-x64-online.run

--- a/internal/utils/logger.go
+++ b/internal/utils/logger.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var Log = logrus.New()

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func ExistsFile(name string) bool {

--- a/internal/utils/walk_test.go
+++ b/internal/utils/walk_test.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	assert "github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
Use the new canonical project URL (note the lowercase 's') for logrus to prevent duplicate checkouts & imports of logrus.

See https://github.com/sirupsen/logrus/pull/384