### PR TITLE
Fix for bundling when using MSYS2 outside of MSYS2 Shell

### DIFF
--- a/internal/cmd/deploy/bundle.go
+++ b/internal/cmd/deploy/bundle.go
@@ -250,7 +250,11 @@ func bundle(mode, target, path, name, depPath string) {
 				if strings.Contains(output, lib) && lib != parser.MOC {
 					for _, lib := range append(deps, lib) {
 						if utils.ExistsFile(filepath.Join(libraryPath, fmt.Sprintf("Qt5%v.dll", lib))) {
-							utils.RunCmd(exec.Command(copyCmd, filepath.Join(libraryPath, fmt.Sprintf("Qt5%v.dll", lib)), depPath), fmt.Sprintf("copy %v for %v on %v", lib, target, runtime.GOOS))
+							if utils.MSYSTEM() != "" {
+								utils.RunCmd(exec.Command(copyCmd, filepath.Join(libraryPath, fmt.Sprintf("Qt5%v.dll", lib)), depPath), fmt.Sprintf("copy %v for %v on %v", lib, target, runtime.GOOS))
+							} else {
+								utils.RunCmd(exec.Command("xcopy", "/Y", filepath.Join(libraryPath, fmt.Sprintf("Qt5%v.dll", lib)), depPath), fmt.Sprintf("copy %v for %v on %v", lib, target, runtime.GOOS))
+							}							
 						}
 					}
 				}


### PR DESCRIPTION
When using a setup where you are outside of MSYS2 shell, but you still want to use the MSYS2 build of Qt binaries for 64bit.  You can see the configuration here https://github.com/rashwell/neochess/wiki/NeoChess-Building-on-Windows-with-MSYS2,-VSCode,-and-64-bit-Qt the build and bundle deploy works fine, but without the /Y switch to the xcopy in the patch here, the bundle process displays errors.