### PR TITLE
remove spurious #include <ui>

### DIFF
--- a/internal/binding/templater/template_cpp.go
+++ b/internal/binding/templater/template_cpp.go
@@ -525,7 +525,8 @@ func preambleCpp(module string, input []byte, mode int, tags string) []byte {
 				"QPlatformGraphicsBuffer",
 				"QDBusPendingReplyTypes",
 				"QRemoteObjectPackets",
-				"QRemoteObjectStringLiterals":
+				"QRemoteObjectStringLiterals",
+				"ui":
 				{
 					continue
 				}


### PR DESCRIPTION
remove #include <ui> which leads to compilation failing because cpp can't find any ui.h

caveat: I did not research why ui.h is included and if it would be needed in any situations.