### PR TITLE
Update audio-visualizer-qml example to work with Qt 5.9.x

### DIFF
--- a/internal/examples/qt3d/audio-visualizer-qml/Visualizer.qml
+++ b/internal/examples/qt3d/audio-visualizer-qml/Visualizer.qml
@@ -189,8 +189,8 @@ Entity {
 
             NormalDiffuseMapAlphaMaterial {
                 id: titlePlaneMaterial
-                diffuse: "qrc:/images/demotitle.png"
-                normal: "qrc:/images/normalmap.png"
+                diffuse: TextureLoader { source: "qrc:/images/demotitle.png" }
+                normal: TextureLoader { source: "qrc:/images/normalmap.png" }
                 shininess: 1.0
             }
 
@@ -215,8 +215,8 @@ Entity {
             }
 
             property Material songPlaneMaterial: NormalDiffuseMapAlphaMaterial {
-                diffuse: "qrc:/images/songtitle.png"
-                normal: "qrc:/images/normalmap.png"
+                diffuse: TextureLoader { source: "qrc:/images/songtitle.png" }
+                normal: TextureLoader { source: "qrc:/images/normalmap.png" }
                 shininess: 1.0
             }
 


### PR DESCRIPTION
This small update adjusts the audio-visualizer-qml example to work with Qt-5.9.x.

The changes were copied verbatim from the BSD licensed Qt-5.9.0 Visualizer.qml example file from qt.io.
  