### PR TITLE
Fix for MSYS2 being installed on drive other than C:\

### DIFF
--- a/internal/utils/windows.go
+++ b/internal/utils/windows.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 func QT_MSYS2() bool {
@@ -18,6 +19,7 @@ func QT_MSYS2_DIR() string {
 		}
 		return filepath.Join(dir, "mingw32")
 	}
+	drive := strings.Split(dir, string(os.PathSeparator))[0]
 	prefix := "msys32"
 	if runtime.GOARCH == "amd64" {
 		prefix = "msys64"
@@ -26,7 +28,7 @@ func QT_MSYS2_DIR() string {
 	if QT_MSYS2_ARCH() == "amd64" {
 		suffix = "mingw64"
 	}
-	return fmt.Sprintf("C:\\%v\\%v", prefix, suffix)
+	return fmt.Sprintf("%v\\%v\\%v", drive, prefix, suffix)
 }
 
 func IsMsys2QtDir() bool {


### PR DESCRIPTION
Changed `func QT_MSYS2_DIR()` to return a path to a general letter drive rather than the hardcoded `C:\` drive.
My MSYS2 install was on `E:\` and the function was returning a path on `C:\` where my MSYS2 install could not be found.
Sorry, but my C:\ drive was full :) 