### PR TITLE
add a method 'addItem‘ to QGridLayout

### DIFF
--- a/widgets/widgets.cpp
+++ b/widgets/widgets.cpp
@@ -30727,6 +30727,16 @@ void QGridLayout_AddWidget(void* ptr, void* widget, int row, int column, long lo
 		static_cast<QGridLayout*>(ptr)->addWidget(static_cast<QWidget*>(widget), row, column, static_cast<Qt::AlignmentFlag>(alignment));
 }
 
+void QGridLayout_AddItem2(void* ptr, void* item, int row, int column, int rowSpan, int columnSpan, long long alignment)
+{
+		static_cast<QGridLayout*>(ptr)->addItem(static_cast<QLayoutItem*>(item), row, column, rowSpan, columnSpan, static_cast<Qt::AlignmentFlag>(alignment));
+}
+
+void QGridLayout_AddItem3(void* ptr, void* item, int row, int column, long long alignment)
+{
+		static_cast<QGridLayout*>(ptr)->addItem(static_cast<QLayoutItem*>(item), row, column, 1, 1, static_cast<Qt::AlignmentFlag>(alignment));
+}
+
 void QGridLayout_SetColumnMinimumWidth(void* ptr, int column, int minSize)
 {
 	static_cast<QGridLayout*>(ptr)->setColumnMinimumWidth(column, minSize);

--- a/widgets/widgets.go
+++ b/widgets/widgets.go
@@ -50205,6 +50205,18 @@ func (ptr *QGridLayout) AddWidget(widget QWidget_ITF, row int, column int, align
 	}
 }
 
+func (ptr *QGridLayout) AddItem2(item QLayoutItem_ITF, row int, column int, rowSpan int, columnSpan int, alignment core.Qt__AlignmentFlag) {
+	if ptr.Pointer() != nil {
+		C.QGridLayout_AddItem2(ptr.Pointer(), PointerFromQLayoutItem(item), C.int(int32(row)), C.int(int32(column)), C.int(int32(rowSpan)), C.int(int32(columnSpan)), C.longlong(alignment))
+	}
+}
+
+func (ptr *QGridLayout) AddItem3(item QLayoutItem_ITF, row int, column int, alignment core.Qt__AlignmentFlag) {
+	if ptr.Pointer() != nil {
+		C.QGridLayout_AddItem3(ptr.Pointer(), PointerFromQLayoutItem(item), C.int(int32(row)), C.int(int32(column)), C.longlong(alignment))
+	}
+}
+
 func (ptr *QGridLayout) SetColumnMinimumWidth(column int, minSize int) {
 	if ptr.Pointer() != nil {
 		C.QGridLayout_SetColumnMinimumWidth(ptr.Pointer(), C.int(int32(column)), C.int(int32(minSize)))

--- a/widgets/widgets.h
+++ b/widgets/widgets.h
@@ -3763,6 +3763,8 @@ void QGridLayout_AddLayout(void* ptr, void* layout, int row, int column, long lo
 void QGridLayout_AddLayout2(void* ptr, void* layout, int row, int column, int rowSpan, int columnSpan, long long alignment);
 void QGridLayout_AddWidget3(void* ptr, void* widget, int fromRow, int fromColumn, int rowSpan, int columnSpan, long long alignment);
 void QGridLayout_AddWidget(void* ptr, void* widget, int row, int column, long long alignment);
+void QGridLayout_AddItem2(void* ptr, void* item, int row, int column, int rowSpan, int columnSpan, long long alignment);
+void QGridLayout_AddItem3(void* ptr, void* item, int row, int column, long long alignment);
 void QGridLayout_SetColumnMinimumWidth(void* ptr, int column, int minSize);
 void QGridLayout_SetColumnStretch(void* ptr, int column, int stretch);
 void QGridLayout_SetHorizontalSpacing(void* ptr, int spacing);


### PR DESCRIPTION
Hey

There is a description of "addItem" in the [QGridLayout document](http://doc.qt.io/qt-5/qgridlayout.html#addItem), but this method is not implemented in goqt. When you need to use something like QSpacerItem, you will have some trouble, so I implemented this method according to the documentation.