### PR TITLE
Fix 2dpainting example build

### DIFF
--- a/internal/examples/opengl/2dpainting/helper.go
+++ b/internal/examples/opengl/2dpainting/helper.go
@@ -54,5 +54,5 @@ func (h *Helper) Paint(painter *gui.QPainter, event *gui.QPaintEvent, elapsed in
 
 	painter.SetPen(h.textPen)
 	painter.SetFont(h.textFont)
-	painter.DrawText6(core.NewQRect4(-50, -50, 100, 100), int(core.Qt__AlignCenter), "Qt", core.NewQRect())
+	painter.DrawText4(core.NewQRect4(-50, -50, 100, 100), int(core.Qt__AlignCenter), "Qt", core.NewQRect())
 }

--- a/internal/examples/opengl/2dpainting/window.go
+++ b/internal/examples/opengl/2dpainting/window.go
@@ -30,10 +30,10 @@ func (w *Window) init() {
 	openGLLabel.SetAlignment(core.Qt__AlignHCenter)
 
 	layout := widgets.NewQGridLayout(nil)
-	layout.AddWidget(native, 0, 0, 0)
-	layout.AddWidget(openGL, 0, 1, 0)
-	layout.AddWidget(nativeLabel, 1, 0, 0)
-	layout.AddWidget(openGLLabel, 1, 1, 0)
+	layout.AddWidget2(native, 0, 0, 0)
+	layout.AddWidget2(openGL, 0, 1, 0)
+	layout.AddWidget2(nativeLabel, 1, 0, 0)
+	layout.AddWidget2(openGLLabel, 1, 1, 0)
 	w.SetLayout(layout)
 
 	timer := core.NewQTimer(nil)


### PR DESCRIPTION
I'm a complete noob with the library, but I was interested in the internal/opengl/2dpainting example. I needed to make the following changes to get it to build; there seemed to be some kind of order reshuffling of these indexed functions.

I'm building following the suggested method in the docs:
```
qtdeploy test desktop github.com/therecipe/qt/internal/examples/opengl/2dpainting
```