### PR TITLE
fix QGroupBox SetAlignment

### DIFF
--- a/internal/cmd/rcc/rcc.go
+++ b/internal/cmd/rcc/rcc.go
@@ -448,7 +448,12 @@ func rcc(path, target, tagsCustom, output_dir string, quickcompiler bool, useuic
 							l = strings.Replace(l, ".SetTextAlignment(", ".SetTextAlignment(int(", -1)
 							l = strings.TrimSuffix(l, ")") + "))"
 						}
-
+						
+						if strings.Contains(l, ".SetAlignment(") {
+							l = strings.Replace(l, ".SetAlignment(", ".SetAlignment(int(", -1)
+							l = strings.TrimSuffix(l, ")") + "))"
+						}
+						
 						if strings.Contains(l, ".AddAction(") {
 							l = strings.Replace(l, ".AddAction(", ".AddActions([]*widgets.QAction{", -1)
 							l = strings.TrimSuffix(l, ")") + "})"


### PR DESCRIPTION
>cannot use "github.com/therecipe/qt/core".Qt__AlignRight | "github.com/therecipe/qt/core".Qt__AlignTrailing | "github.com/therecipe/qt/core".Qt__AlignVCenter (type "github.com/therecipe/qt/core".Qt__AlignmentFlag) as type int in argument to w.GroupBox.SetAlignment