### PR TITLE
Added suport for customizable Android API level

### DIFF
--- a/internal/binding/templater/template_cgo_qmake.go
+++ b/internal/binding/templater/template_cgo_qmake.go
@@ -311,7 +311,7 @@ func createMakefile(module, path, target string, mode int) {
 		cmd.Args = append(cmd.Args, []string{"-spec", "macx-ios-clang", "CONFIG+=iphonesimulator", "CONFIG+=simulator"}...)
 	case "android", "android-emulator":
 		cmd.Args = append(cmd.Args, []string{"-spec", "android-clang"}...)
-		cmd.Env = []string{fmt.Sprintf("ANDROID_NDK_ROOT=%v", utils.ANDROID_NDK_DIR())}
+		cmd.Env = []string{fmt.Sprintf("ANDROID_NDK_ROOT=%v", utils.ANDROID_NDK_DIR()), fmt.Sprintf("ANDROID_NDK_PLATFORM=%v", utils.ANDROID_NDK_PLATFORM())}
 	case "sailfish", "sailfish-emulator":
 		cmd.Args = append(cmd.Args, []string{"-spec", "linux-g++"}...)
 		cmd.Env = []string{

--- a/internal/utils/android.go
+++ b/internal/utils/android.go
@@ -117,3 +117,19 @@ func ANDROID_NDK_NOSTDLIBPP_LDFLAG() string {
 	}
 	return ""
 }
+
+// ANDROID_NDK_PLATFORM returns the Android API level to use in the building process
+func ANDROID_NDK_PLATFORM() string {
+
+	// default value as set in cmd.go BuildEnv function
+	if QT_FELGO() {
+		return "android-16"
+	}
+	// if env var exists and is not empty use env var of the system
+	if value, exist := os.LookupEnv("ANDROID_NDK_PLATFORM"); exist && value != "" {
+		return value
+	}
+
+	// default value as set in cmd.go BuildEnv function
+	return "android-21"
+}


### PR DESCRIPTION
The Android API level can be customized changing the ANDROID_NDK_PLATFORM environment variable innthe host system. The value of this variable will be passed to QMake to generate the correct flags required to build cgo using the Android NDK toolchain as backend.

This will prevent linking errors and warnings using Qt 5.12.x and NDK r20+