### PR TITLE
Fixed mismatching -D__ANDROID_API__ cgo flag thorough building steps

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -573,10 +573,7 @@ func BuildEnv(target, name, depPath string) (map[string]string, []string, []stri
 	var out string
 	var env map[string]string
 
-	androidAPI := "21"
-	if utils.QT_FELGO() {
-		androidAPI = "16"
-	}
+	androidAPI := utils.ANDROID_NDK_PLATFORM()
 
 	switch target {
 	case "android":
@@ -604,7 +601,7 @@ func BuildEnv(target, name, depPath string) (map[string]string, []string, []stri
 			"CGO_LDFLAGS": fmt.Sprintf("-Wno-unused-command-line-argument -D__ANDROID_API__=%v -target armv7-none-linux-androideabi -gcc-toolchain %v --sysroot=%v",
 				androidAPI,
 				filepath.Join(utils.ANDROID_NDK_DIR(), "toolchains", "arm-linux-androideabi-4.9", "prebuilt", runtime.GOOS+"-x86_64"),
-				filepath.Join(utils.ANDROID_NDK_DIR(), "platforms", "android-21", "arch-arm")),
+				filepath.Join(utils.ANDROID_NDK_DIR(), "platforms", androidAPI, "arch-arm")),
 		}
 		if runtime.GOOS == "windows" {
 			env["TMP"] = os.Getenv("TMP")

--- a/internal/utils/android.go
+++ b/internal/utils/android.go
@@ -130,6 +130,7 @@ func ANDROID_NDK_PLATFORM() string {
 		return value
 	}
 
-	// default value as set in cmd.go BuildEnv function
+	// default value as recommended in https://wiki.qt.io/Qt_for_Android_known_issues
+	// to workaround problems with arm64 android builds
 	return "android-21"
 }


### PR DESCRIPTION
This should fix some instances of error warning that `__ANDROID_API__` macro is redefinied when system `$ANDROID_NDK_PLATFORM` was different than default value (android-21)