### PR TITLE
qt/internal/cmd/deploy: correcly escape ldflags on linux

### DIFF
--- a/internal/cmd/deploy/build_escape.go
+++ b/internal/cmd/deploy/build_escape.go
@@ -31,8 +31,8 @@ func escapeFlags(ldFlags []string, ldFlagsCustom string) string {
 		ldFlags = append(ldFlags, strings.Split(ldFlagsCustom, " ")...)
 	}
 
-	if out := strings.Replace(strings.Join(ldFlags, "\" \""), "_DONT_ESCAPE_", " ", -1); len(out) > 0 {
-		return fmt.Sprintf("\"%v\"", out)
+	if out := strings.Replace(strings.Join(ldFlags, " "), "_DONT_ESCAPE_", " ", -1); len(out) > 0 {
+		return fmt.Sprintf("%q", out)
 	}
 	return ""
 }


### PR DESCRIPTION
Use fmt.Printf %q verb which automatically double quotes the given string,
therefore eliminating the need for double quote escapes.

Closes #1045