### PR TITLE
Fixing qtmoc not handling pointer to object in QT signal properly

### DIFF
--- a/internal/binding/templater/function_go.go
+++ b/internal/binding/templater/function_go.go
@@ -364,7 +364,11 @@ func goFunctionBody(function *parser.Function) string {
 						if !strings.HasSuffix(function.Name, "Changed") { //TODO: check if property instead
 							fmt.Fprintf(bb, "qt.UnregisterTemp(unsafe.Pointer(uintptr(%v)))\n", parser.CleanName(p.Name, p.Value))
 						}
-						fmt.Fprintf(bb, "%[1]vD = (*(*%v)(%[1]vI))\n", parser.CleanName(p.Name, p.Value), p.PureGoType)
+						if strings.HasPrefix(p.PureGoType, "*") {
+							fmt.Fprintf(bb, "%[1]vD = (%v)(%[1]vI)\n", parser.CleanName(p.Name, p.Value), p.PureGoType)
+						} else {
+							fmt.Fprintf(bb, "%[1]vD = (*(*%v)(%[1]vI))\n", parser.CleanName(p.Name, p.Value), p.PureGoType)
+						}
 						fmt.Fprint(bb, "}\n")
 					}
 				}


### PR DESCRIPTION
The callback is returning the value of the pointer instead of the pointer. 

In the change function definition if the value is an Object, we are transmitting the address of the object and if it is a pointer, we are transmitting directly the pointer.

However in the callback function, we do not make such distinction resulting in casting the value of the initial pointer to a pointer and using it for the function call instead of the initial pointer.

Happy to discuss if my code is not a good fit ^^.

Best regards,

Aurryon