### PR TITLE
ANDROID_EXTRA_LIBS and ANDROID_MODULES_INCLUDE for library inclusion

### DIFF
--- a/internal/binding/templater/template_cpp.go
+++ b/internal/binding/templater/template_cpp.go
@@ -858,6 +858,11 @@ extern "C" int32_t __isPlatformVersionAtLeast(int32_t Platform, int32_t Major, i
 					old()
 				}
 			}
+
+			if target == "android" || target == "android-emulator" {
+				utils.ADD_ANDROID_MODULES_INCLUDE(strings.TrimPrefix(module, "Qt"))
+			}
+
 		}
 	}
 

--- a/internal/cmd/deploy/assets.go
+++ b/internal/cmd/deploy/assets.go
@@ -136,9 +136,11 @@ func android_config(target, path, depPath string) string {
 		if utils.ANDROID_EXTRA_LIBS() != "" {
 			jsonStruct.AndroidExtraLibs += "," + utils.ANDROID_EXTRA_LIBS()
 		}
-		modules := strings.Split(utils.ANDROID_MODULES_INCLUDE(), ",")
-		for _, module := range modules {
-			jsonStruct.AndroidExtraLibs += "," + filepath.Join(utils.QT_INSTALL_PREFIX(target), "lib", fmt.Sprintf("libQt5%s.so", module))
+		if utils.ANDROID_MODULES_INCLUDE() != "" {
+			modules := strings.Split(utils.ANDROID_MODULES_INCLUDE(), ",")
+			for _, module := range modules {
+				jsonStruct.AndroidExtraLibs += "," + filepath.Join(utils.QT_INSTALL_PREFIX(target), "lib", fmt.Sprintf("libQt5%s.so", module))
+			}
 		}
 	}
 

--- a/internal/cmd/deploy/assets.go
+++ b/internal/cmd/deploy/assets.go
@@ -132,6 +132,16 @@ func android_config(target, path, depPath string) string {
 		}
 	}
 
+	if target == "android" || target == "android-emulator" {
+		if utils.ANDROID_EXTRA_LIBS() != "" {
+			jsonStruct.AndroidExtraLibs += "," + utils.ANDROID_EXTRA_LIBS()
+		}
+		modules := strings.Split(utils.ANDROID_MODULES_INCLUDE(), ",")
+		for _, module := range modules {
+			jsonStruct.AndroidExtraLibs += "," + filepath.Join(utils.QT_INSTALL_PREFIX(target), "lib", fmt.Sprintf("libQt5%s.so", module))
+		}
+	}
+
 	out, err := json.Marshal(jsonStruct)
 	if err != nil {
 		utils.Log.WithError(err).Panicf("failed to create json-config file for androiddeployqt on %v", runtime.GOOS)

--- a/internal/utils/android.go
+++ b/internal/utils/android.go
@@ -140,3 +140,11 @@ func ANDROID_NDK_PLATFORM() string {
 	// to workaround problems with arm64 android builds
 	return "android-21"
 }
+
+func ANDROID_EXTRA_LIBS() string {
+	return os.Getenv("ANDROID_EXTRA_LIBS")
+}
+
+func ANDROID_MODULES_INCLUDE() string {
+	return os.Getenv("ANDROID_MODULES_INCLUDE")
+}

--- a/internal/utils/android.go
+++ b/internal/utils/android.go
@@ -148,3 +148,13 @@ func ANDROID_EXTRA_LIBS() string {
 func ANDROID_MODULES_INCLUDE() string {
 	return os.Getenv("ANDROID_MODULES_INCLUDE")
 }
+
+func ADD_ANDROID_MODULES_INCLUDE(module string) {
+	val := os.Getenv("ANDROID_MODULES_INCLUDE")
+	mod := module
+
+	if val != "" {
+		mod = "," + mod
+	}
+	os.Setenv("ANDROID_MODULES_INCLUDE", val+mod)
+}


### PR DESCRIPTION
By using this patch the following issues can be addressed:
https://github.com/therecipe/qt/issues/1106
https://github.com/therecipe/qt/issues/1087

The main Problem is, that the json file doesn't include android-extra-libs (normally androiddeployqt would read from the env Var ANDROID_EXTRA_LIBS and include these files to the json)

Two possible use cases are provided here:
1.) Setting ANDROID_EXTRA_LIBS directly (a.e.: ANDROID_EXTRA_LIBS="<QT_INSTALL_PATH>/android_armv64_v8a/lib/libQt5Widgets.so,<QT_INSTALL_PATH>/android_arm64_v8a/lib/libQt5Svg.so,<QT_INSTALL_PATH>/android_arm64_v8a/lib/libQt5QuickWidgets.so" GOARCH="arm64" qtdeploy -debug build android

2.) Using the ANDROID_MODULES_INCLUDE (a.e.: ANDROID_MODULES_INCLUDE="Widgets,Svg,QuickWidgets" qtdeploy -debug build android)

The 2. will add the correct arch and path to the so files.