### PR TITLE
Added "QmlModels" and "QmlWorkerScript" libraries to qtdeploy bundle step 

### DIFF
--- a/internal/cmd/deploy/bundle.go
+++ b/internal/cmd/deploy/bundle.go
@@ -252,7 +252,7 @@ func bundle(mode, target, path, name, depPath string, tagsCustom string, fast bo
 
 			libs := []string{"DBus", "XcbQpa", "Quick", "Widgets", "EglDeviceIntegration", "EglFsKmsSupport", "OpenGL", "WaylandClient", "WaylandCompositor", "QuickControls2", "QuickTemplates2", "QuickWidgets", "QuickParticles", "CLucene", "Concurrent", "Svg", "MultimediaGstTools"}
 			if usesQml {
-				libs = append(libs, []string{"3DCore", "3DExtras", "3DInput", "3DLogic", "3DQuick", "3DQuickExtras", "3DQuickInput", "3DQuickRender", "3DRender", "Gamepad", "Multimedia", "MultimediaQuick"}...)
+				libs = append(libs, []string{"3DCore", "3DExtras", "3DInput", "3DLogic", "3DQuick", "3DQuickExtras", "3DQuickInput", "3DQuickRender", "3DRender", "Gamepad", "Multimedia", "MultimediaQuick", "QmlModels", "QmlWorkerScript"}...)
 			}
 			if usesWebEngine {
 				libs = append(libs, []string{"WebEngine", "WebEngineCore", "WebChannel", "Positioning"}...)


### PR DESCRIPTION
This quick patch fixes an error that freezes an application using Qml built against
Qt 5.15. Apparently, libqtquick2plugin.so tries to load those two libraries during
application startup

This fix was tested successfully with the bindings built against Qt 5.15.0, Qt 5.14.2 and Qt 5.13.2