### PR TITLE
Fix linking error in android deployments using Qt 5.14+ 

### DIFF
--- a/internal/cmd/deploy/build.go
+++ b/internal/cmd/deploy/build.go
@@ -35,7 +35,7 @@ func build(mode, target, path, ldFlagsCustom, tagsCustom, name, depPath string, 
 		utils.Save(filepath.Join(path, "cgo_main_wrapper.go"), "package main\nimport (\n\"C\"\n\"os\"\n\"unsafe\"\n)\n//export go_main_wrapper\nfunc go_main_wrapper(argc C.int, argv unsafe.Pointer) {\nos.Args=make([]string,int(argc))\nfor i,b := range (*[1<<3]*C.char)(argv)[:int(argc):int(argc)] {\nos.Args[i] = C.GoString(b)\n}\nmain()\n}")
 
 		// Quick fix of problem in library soname experienced with Qt 5.14+ and android
-		if utils.QT_VERSION_NUM() >= 5140 {
+		if utils.QT_VERSION_NUM() >= 5140 && strings.HasPrefix(target, "android") {
 			ldFlags = utils.AppendToFlag(ldFlags, "-extldflags", "-Wl,-soname,libgo_base.so")
 		}
 	case "windows":

--- a/internal/cmd/deploy/build.go
+++ b/internal/cmd/deploy/build.go
@@ -33,6 +33,11 @@ func build(mode, target, path, ldFlagsCustom, tagsCustom, name, depPath string, 
 	switch target {
 	case "android", "android-emulator", "ios", "ios-simulator":
 		utils.Save(filepath.Join(path, "cgo_main_wrapper.go"), "package main\nimport (\n\"C\"\n\"os\"\n\"unsafe\"\n)\n//export go_main_wrapper\nfunc go_main_wrapper(argc C.int, argv unsafe.Pointer) {\nos.Args=make([]string,int(argc))\nfor i,b := range (*[1<<3]*C.char)(argv)[:int(argc):int(argc)] {\nos.Args[i] = C.GoString(b)\n}\nmain()\n}")
+
+		// Quick fix of problem in library soname experienced with Qt 5.14+ and android
+		if utils.QT_VERSION_NUM() >= 5140 {
+			ldFlags = utils.AppendToFlag(ldFlags, "-extldflags", "-Wl,-soname,libgo_base.so")
+		}
 	case "windows":
 		ending = ".exe"
 	case "sailfish", "sailfish-emulator":
@@ -59,7 +64,8 @@ func build(mode, target, path, ldFlagsCustom, tagsCustom, name, depPath string, 
 	}
 
 	if utils.Log.Level == logrus.DebugLevel && target != "wasm" {
-		ldFlags = append(ldFlags, "-extldflags=-v")
+		// ldFlags = append(ldFlags, "-extldflags=-v -Wl,-soname,libgo_base.so")
+		ldFlags = utils.AppendToFlag(ldFlags, "-extldflags", "-v")
 	}
 
 	cmd := exec.Command("go", "build", "-p", strconv.Itoa(runtime.GOMAXPROCS(0)), "-v")

--- a/internal/utils/flags.go
+++ b/internal/utils/flags.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AppendToFlag is a quick function that appends content to a flag if is already defined
+func AppendToFlag(flags []string, flag, content string) []string {
+	// no content to append to flag
+	if content == "" {
+		return flags
+	}
+
+	var match bool
+	for index, flagEntry := range flags {
+		if strings.Contains(flagEntry, flag) {
+			flagEntry += " " + content
+			flags[index] = flagEntry
+			match = true
+			break
+		}
+	}
+	// Flag not found, so appends new flag to list
+	if !match {
+		flags = append(flags, fmt.Sprintf("%s=%s", flag, content))
+	}
+
+	return flags
+}
+
+// TODO func SetFlag
+
+// TODO MergeFlags

--- a/internal/utils/flags.go
+++ b/internal/utils/flags.go
@@ -12,10 +12,28 @@ func AppendToFlag(flags []string, flag, content string) []string {
 		return flags
 	}
 
-	var match bool
+	var (
+		extractedFlag     string
+		match, simpleFlag bool
+	)
 	for index, flagEntry := range flags {
-		if strings.Contains(flagEntry, flag) {
-			flagEntry += " " + content
+		// checks if is simple flag or has an assignation
+		if asigIndex := strings.IndexRune(flagEntry, '='); asigIndex != -1 {
+			// extracts flag
+			extractedFlag = flagEntry[:asigIndex]
+			simpleFlag = false
+		} else {
+			extractedFlag = flagEntry
+			simpleFlag = true
+		}
+
+		// if flags are equal appends content to existing assignation
+		if extractedFlag == flag {
+			if !simpleFlag {
+				flagEntry += " " + content
+			} else {
+				flagEntry = fmt.Sprintf("%s=%s", flag, content)
+			}
 			flags[index] = flagEntry
 			match = true
 			break

--- a/internal/utils/flags_test.go
+++ b/internal/utils/flags_test.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendToFlag(t *testing.T) {
+
+	flags := []string{"-p", "-pkgdir=/usr/lib/testdir", "-mod", "-modfile go.mod"}
+
+	flags = AppendToFlag(flags, "-extldflags", "-v")
+	require.Equal(t, "-extldflags=-v", flags[4], "Flag was not inserted")
+
+	flags = AppendToFlag(flags, "-extldflags", "-Wl,soname,libname.so")
+	require.Equal(t, "-extldflags=-v -Wl,soname,libname.so", flags[4], "Flag was not appended with new content")
+
+	flags = AppendToFlag(flags, "-p", "test")
+	require.Equal(t, "-p=test", flags[0], "Content was not appended to simple flag")
+}


### PR DESCRIPTION
The expected shared library soname ("libgo_base.so") is injected to go build using "extldflags" ldflag
This fix was tested successfully on Qt 5.13.2, 5.14.2 and 5.15.0. Previously to this patch, on Qt 5.14.0+
libgo_base.so soname was libruntime_<arch>.so, resulting in linking error when the application was executed
on a device